### PR TITLE
Add `parse` method, add `raise_error` parameter, enhance docstring, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Python library that provides tools for using and validating Telegram web app i
 
 ## Installation
 
-You can install the library using pip.
+You can install the library using pip:
 
 ```bash
 pip install init-data-py
@@ -15,42 +15,60 @@ pip install init-data-py
 
 ## Usage
 
-### Parsing.
+### Parsing
+
+To parse the `window.Telegram.WebApp.initData` query string into an `InitData` object for easier access to attributes and validation, you can use the `InitData.parse` method:
 
 ```python
 from init_data_py import InitData
 
-query_string = "query_id=AAF03wc0Ag..."
+init_data = InitData.parse(query_string)
+```
 
-InitData.from_query_string(query_string)
+### Validation
+
+To validate the init data, you can use the `InitData.validate` method:
+
+```python
+is_valid = init_data.validate(bot_token)
 ```
 
 ### Signing
+
+If you need to create and sign your own init data, you can create an `InitData` object and sign it:
 
 ```python
 from init_data_py import InitData
 from init_data_py.types import User
 
-BOT_TOKEN = "7244657541:AA..."
-
-init_data = InitData(
-    user=User(
-        id=5167898484,
-        first_name="xin",
-        username="pvnimaxin",
-    )
-).sign(bot_token=BOT_TOKEN)
+user = User(id=5167898484, first_name="xin")
+init_data = InitData(user=user).sign(bot_token)
 ```
 
-### Validation
+### Converting InitData to Query String
+
+After creating and signing init data, you can convert it to a query sting using the `InitData.to_query_string` method:
+
+```python
+query_string = init_date.to_query_string()
+```
+
+### Real-World Validation Example
+
+This example demonstrates how to validate a Telegram Mini App init data. It parses the init data query string into an `InitData` object and validate it using the provided bot token, checking that the data is valid and has not expired:
 
 ```python
 from init_data_py import InitData
 
-BOT_TOKEN = "7244657541:AA..."
+bot_token = "7244657541:AAEgqk0HDC3WD5cdbnGMdd6L0TJ74FDp97Y"
+query_string = "query_id=AAF03wc0AgAAAHTfBzROOCVW&user=%7B%22id%22%3A5167898484%2C%22first_name%22%3A%22xin%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22pvnimaxin%22%2C%22language_code%22%3A%22en%22%2C%22allows_write_to_pm%22%3Atrue%7D&auth_date=1722938610&hash=8654c8c617c143abf656f4f159be2539880a56f58c2d9be622f90c0346aa162b"
 
-init_data = InitData(...)
-is_valid = init_data.validate(bot_token=BOT_TOKEN, lifetime=3600)
+init_data = InitData.parse(query_string)
+
+is_valid = init_data.validate(
+    bot_token=bot_token,
+    lifetime=3600,
+)
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "init-data-py"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Python library that provides tools for using and validating Telegram web app init data."
 authors = [
     { name = "nimaxin", email = "nimaxin@proton.me" }

--- a/src/init_data_py/__init__.py
+++ b/src/init_data_py/__init__.py
@@ -1,5 +1,5 @@
 from .init_data import InitData
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = ["InitData"]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -21,9 +21,9 @@ class TestParseInitData(unittest.TestCase):
         )
 
     def test_valid_query_string(self):
-        init_data = InitData.from_query_string(self.query_string)
+        init_data = InitData.parse(self.query_string)
         self.assertEqual(init_data, self.expected_init_data)
 
     def test_invalid_query_string(self):
         with self.assertRaises(errors.UnexpectedFormatError):
-            InitData.from_query_string(self.query_string.upper())
+            InitData.parse(self.query_string.upper())

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -24,9 +24,10 @@ class TestSignInitData(unittest.TestCase):
         )
 
     def test_sign(self):
-        self.init_data.sign(
+        init_data = self.init_data.sign(
             bot_token=self.bot_token,
             auth_date=self.expected_auth_date,
         )
         self.assertEqual(self.init_data.hash, self.expected_hash)
         self.assertEqual(self.init_data.auth_date, self.expected_auth_date)
+        self.assertIsInstance(init_data, InitData)

--- a/tests/test_to_query_string.py
+++ b/tests/test_to_query_string.py
@@ -1,0 +1,11 @@
+import unittest
+
+from init_data_py import InitData
+
+
+class TestToQueryString(unittest.TestCase):
+    def test_from_query_string_to_query_string(self):
+        query_string = "query_id=AAF03wc0AgAAAHTfBzROOCVW&user=%7B%22id%22%3A5167898484%2C%22first_name%22%3A%22xin%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22pvnimaxin%22%2C%22language_code%22%3A%22en%22%2C%22allows_write_to_pm%22%3Atrue%7D&auth_date=1722938610&hash=8654c8c617c143abf656f4f159be2539880a56f58c2d9be622f90c0346aa162b"
+        init_data = InitData.parse(query_string)
+        generated_query_string = init_data.to_query_string()
+        self.assertEqual(generated_query_string, query_string)


### PR DESCRIPTION
- Added the `parse` method for clarity instead of `from_query_string`.
- Added `raise_error` parameter to the `validate` method to control exception handling.
- Improved the docstring of the `parse` method for better understanding.
- Update README with improved examples and usage instructions.
- Make validate method exceptions raising optional.
- Bumped version to reflect recent changes.